### PR TITLE
align erc20 template with evm standard and fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Reusable smart contract templates for EVM (Solidity + Foundry) and Solana (Ancho
 
 ## Structure
 
-`evm/`           # Solidity contracts with Foundry
+`evm/`           # Solidity contract templates (Hardhat + TypeScript tests)
 `solana/`        # Anchor programs
 
 ## EVM Contracts (Planned)

--- a/evm/TEMPLATE_STANDARD.md
+++ b/evm/TEMPLATE_STANDARD.md
@@ -53,7 +53,7 @@ Every template must include a `.env.example` with all required environment varia
 
 ```
 PRIVATE_KEY=
-ALCHEMY_KEY=
+ALCHEMY_URL=
 ETHERSCAN_API_KEY=
 ```
 

--- a/evm/token-erc20/.learn.md
+++ b/evm/token-erc20/.learn.md
@@ -25,8 +25,10 @@ The owner can create new tokens up to a maximum supply cap:
 
 ```solidity
 function mint(address to, uint256 amount) public onlyOwner {
-    require(totalSupply() + amount <= maxSupply, "Minting more than max supply");
+    uint256 remaining = maxSupply - totalSupply();
+    if (amount > remaining) revert ExceedsMaxSupply(amount, remaining);
     _mint(to, amount);
+    emit Mint(to, amount);
 }
 ```
 
@@ -92,14 +94,28 @@ The standard `approve` function has a known front-running issue. If you want to 
 
 ## Deployment
 
+From the `evm/token-erc20` directory:
+
 ```bash
-npx hardhat ignition deploy ERC20deploy.ts --network sepolia
+npx hardhat ignition deploy ignition/modules/ERC20deploy.ts --network sepolia
 ```
 
-To deploy with custom parameters:
+To deploy with custom parameters, put values in a JSON file (module id matches `buildModule` in `ignition/modules/ERC20deploy.ts`, here `TokenERC20Module`):
+
+```json
+{
+  "TokenERC20Module": {
+    "name": "Phantom",
+    "symbol": "PHT",
+    "maxSupply": "1000000000000000000000000"
+  }
+}
+```
+
+Then run:
 
 ```bash
-npx hardhat ignition deploy ERC20deploy.ts --network sepolia --parameters '{"name":"Phantom","symbol":"PHT","maxSupply":"1000000000000000000000000"}'
+npx hardhat ignition deploy ignition/modules/ERC20deploy.ts --network sepolia --parameters ./deploy-params.json
 ```
 
 Constructor parameters:

--- a/evm/token-erc20/src/ERC20.sol
+++ b/evm/token-erc20/src/ERC20.sol
@@ -8,7 +8,8 @@ import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC2
 import {ERC20Pausable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Pausable.sol";
 import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 
-error ExceedsMaxSupply(uint256 requested, uint256 available);
+error ExceedsMaxSupply(uint256 amount, uint256 remainingMintable);
+error ZeroMaxSupply();
 
 contract TokenERC20 is ERC20, ERC20Burnable, ERC20Pausable, Ownable, ERC20Permit {
 
@@ -19,9 +20,8 @@ contract TokenERC20 is ERC20, ERC20Burnable, ERC20Pausable, Ownable, ERC20Permit
         Ownable(initialOwner)
         ERC20Permit(name)
     {
-        require(_maxSupply > 0, "Max Supply must be greater than 0");
+        if (_maxSupply == 0) revert ZeroMaxSupply();
         maxSupply = _maxSupply;
-
     }
 
     event Mint(address indexed to, uint256 amount);
@@ -35,8 +35,8 @@ contract TokenERC20 is ERC20, ERC20Burnable, ERC20Pausable, Ownable, ERC20Permit
     }
 
     function mint(address to, uint256 amount) public onlyOwner {
-        if (totalSupply() + amount > maxSupply) 
-        revert ExceedsMaxSupply(totalSupply() + amount, maxSupply - totalSupply());
+        uint256 remaining = maxSupply - totalSupply();
+        if (amount > remaining) revert ExceedsMaxSupply(amount, remaining);
         _mint(to, amount);
         emit Mint(to, amount);
     }

--- a/evm/token-erc20/test/ERC20Test.ts
+++ b/evm/token-erc20/test/ERC20Test.ts
@@ -27,7 +27,7 @@ describe("TokenERC20", function () {
       const Token = await ethers.getContractFactory("TokenERC20");
       await expect(
         Token.deploy(owner.address, NAME, SYMBOL, 0),
-      ).to.be.revertedWith("Max Supply must be greater than 0");
+      ).to.be.revertedWithCustomError(Token, "ZeroMaxSupply");
     });
     it("should set the correct name", async function () {
       expect(await token.name()).to.equal(NAME);


### PR DESCRIPTION
## summary

This brings the existing \	oken-erc20\ template in line with \evm/TEMPLATE_STANDARD.md\ and fixes a few doc mismatches.

## contract

- Replaced the constructor \
equire\ string with a \ZeroMaxSupply\ custom error (gas and consistency with the standard).
- Clarified \ExceedsMaxSupply\ to use \(amount, remainingMintable)\ so revert data matches intent.

## docs

- Root README: EVM stack is Hardhat + TypeScript tests, not Foundry-only wording.
- \TEMPLATE_STANDARD.md\: \.env.example\ vars now use \ALCHEMY_URL\ (matches the template).
- \.learn.md\: mint snippet matches the Solidity; deployment section uses the correct Ignition module path, \--parameters\ as a JSON file, and notes the module id for parameters.

## tests

- Deployment test now expects \ZeroMaxSupply\.
- Ran \
px hardhat test\ in \evm/token-erc20\: all 40 passing.


