### PR TITLE
ci: add GitHub Actions workflow with Hardhat and Foundry support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      evm-dirs: ${{ steps.find.outputs.dirs }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: find
+        run: |
+          # Find all directories containing either hardhat.config.ts or foundry.toml
+          dirs=$(find evm -maxdepth 2 \( -name "hardhat.config.ts" -o -name "hardhat.config.js" -o -name "foundry.toml" \) -exec dirname {} \; | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          echo "dirs=$dirs" >> $GITHUB_OUTPUT
+
+  evm:
+    needs: detect
+    if: needs.detect.outputs.evm-dirs != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dir: ${{ fromJson(needs.detect.outputs.evm-dirs) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Hardhat path
+      - name: Setup Node.js
+        if: hashFiles(format('{0}/hardhat.config.ts', matrix.dir)) != '' || hashFiles(format('{0}/hardhat.config.js', matrix.dir)) != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ${{ matrix.dir }}/package-lock.json
+      - name: Install dependencies (Hardhat)
+        if: hashFiles(format('{0}/hardhat.config.ts', matrix.dir)) != '' || hashFiles(format('{0}/hardhat.config.js', matrix.dir)) != ''
+        run: npm ci
+      - name: Compile (Hardhat)
+        if: hashFiles(format('{0}/hardhat.config.ts', matrix.dir)) != '' || hashFiles(format('{0}/hardhat.config.js', matrix.dir)) != ''
+        run: npx hardhat compile
+      - name: Test (Hardhat)
+        if: hashFiles(format('{0}/hardhat.config.ts', matrix.dir)) != '' || hashFiles(format('{0}/hardhat.config.js', matrix.dir)) != ''
+        run: npx hardhat test
+
+      # Foundry path
+      - name: Install Foundry
+        if: hashFiles(format('{0}/foundry.toml', matrix.dir)) != ''
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Build (Foundry)
+        if: hashFiles(format('{0}/foundry.toml', matrix.dir)) != ''
+        run: forge build
+      - name: Test (Foundry)
+        if: hashFiles(format('{0}/foundry.toml', matrix.dir)) != ''
+        run: forge test -vvv


### PR DESCRIPTION
## Summary
- Add CI workflow that triggers on PRs to main and pushes to main
- Auto-detects EVM template directories and their toolchain (Hardhat or Foundry)
- Uses matrix strategy to test each template in parallel
- Hardhat path: `npm ci` → `hardhat compile` → `hardhat test`
- Foundry path: `forge build` → `forge test -vvv`

## Test plan
- [ ] Verify CI triggers on this PR and the `evm/token-erc20` Hardhat tests pass
- [ ] Add a Foundry-based template later and confirm it is auto-detected and tested