### PR TITLE
Fix minor issues in nft-erc721 recipe

### DIFF
--- a/evm/nft-erc721/.gitignore
+++ b/evm/nft-erc721/.gitignore
@@ -13,5 +13,5 @@ node_modules
 /coverage
 /coverage.json
 
-#Deployement files
+# Deployment files
 /ignition/deployments

--- a/evm/nft-erc721/README.md
+++ b/evm/nft-erc721/README.md
@@ -24,7 +24,7 @@ npx hardhat test
 ## Deploy
 
 ```bash
-npx hardhat ignition deploy igniton/modules/NFT721Deploy.ts --network sepolia
+npx hardhat ignition deploy ignition/modules/NFT721Deploy.ts --network sepolia
 ```
 
 ## Learn
@@ -34,7 +34,3 @@ See [.learn.md](./.learn.md) for a breakdown of the ERC-721 standard, metadata p
 ## Stack
 
 Solidity | Hardhat | OpenZeppelin | Ethers.js | TypeScript
-
-```
-
-```

--- a/evm/nft-erc721/hardhat.config.ts
+++ b/evm/nft-erc721/hardhat.config.ts
@@ -5,7 +5,6 @@ dotenv.config();
 
 const isLocalNetwork = !process.env.ALCHEMY_URL;
 if (!isLocalNetwork) {
-  if (!process.env.ALCHEMY_URL) throw new Error("ALCHEMY_URL not set");
   if (!process.env.PRIVATE_KEY) throw new Error("PRIVATE_KEY not set");
   if (!process.env.ETHERSCAN_API_KEY)
     throw new Error("ETHERSCAN_API_KEY not set");

--- a/evm/nft-erc721/package-lock.json
+++ b/evm/nft-erc721/package-lock.json
@@ -4,7 +4,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "hardhat-project",
+      "name": "nft-erc721",
       "dependencies": {
         "@openzeppelin/contracts": "^5.6.1",
         "dotenv": "^17.4.2"

--- a/evm/nft-erc721/src/NFT721.sol
+++ b/evm/nft-erc721/src/NFT721.sol
@@ -25,7 +25,7 @@ contract NFT721 is ERC721, ERC721Enumerable, ERC721URIStorage, ERC2981, Ownable 
     /// @dev Ensures royalty fee is within valid range (<= 10000 basis points)
     /// @param _fee Royalty fee in basis points
     modifier checkFee(uint96 _fee) {
-        if(_fee > 10000) revert InvalidFee(_fee);
+        if (_fee > 10000) revert InvalidFee(_fee);
         _;
     }
 
@@ -65,17 +65,16 @@ contract NFT721 is ERC721, ERC721Enumerable, ERC721URIStorage, ERC2981, Ownable 
         checkFee(feeNumerator)
         returns (uint256)
     {
-        if(bytes(uri).length == 0) revert NoURI();
-        if(royaltyReceiver == address(0)) {
-            if(feeNumerator > 0) revert InvalidFee(feeNumerator);
+        if (bytes(uri).length == 0) revert NoURI();
+        if (royaltyReceiver == address(0)) {
+            if (feeNumerator > 0) revert InvalidFee(feeNumerator);
         }
-           
 
         uint256 tokenId = _nextTokenId++;
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);
 
-        if(royaltyReceiver != address(0)){
+        if (royaltyReceiver != address(0)) {
             _setTokenRoyalty(tokenId, royaltyReceiver, feeNumerator);
         }
 
@@ -93,7 +92,7 @@ contract NFT721 is ERC721, ERC721Enumerable, ERC721URIStorage, ERC2981, Ownable 
         checkFee(feeNumerator)
         onlyOwner
     {
-        if(royaltyReceiver == address(0)) revert NullAddress();
+        if (royaltyReceiver == address(0)) revert NullAddress();
 
         _setDefaultRoyalty(royaltyReceiver, feeNumerator);
         emit DefaultRoyaltyUpdate(royaltyReceiver, feeNumerator);

--- a/evm/nft-erc721/test/NFT721Test.ts
+++ b/evm/nft-erc721/test/NFT721Test.ts
@@ -108,6 +108,20 @@ describe("NFT721", function () {
         .to.be.revertedWithCustomError(nft, "InvalidFee")
         .withArgs(invalidFee);
     });
+
+    it("should revert if royalty receiver is zero address with non-zero fee", async function () {
+      await expect(
+        nft.safeMint(alice.address, TOKEN_URI, ethers.ZeroAddress, DEFAULT_FEE),
+      )
+        .to.be.revertedWithCustomError(nft, "InvalidFee")
+        .withArgs(DEFAULT_FEE);
+    });
+
+    it("should allow minting with zero address receiver and zero fee", async function () {
+      await expect(
+        nft.safeMint(alice.address, TOKEN_URI, ethers.ZeroAddress, 0),
+      ).to.not.be.reverted;
+    });
   });
 
   describe("setDefaultRoyalty", function () {


### PR DESCRIPTION
## Summary

Follow-up fixes from [PR #19](https://github.com/w3-kit/contracts/pull/19) review:

- Fix README typo (`igniton` → `ignition`) and remove trailing empty code fences
- Fix `.gitignore` typo (`Deployement` → `Deployment`)
- Remove unreachable `ALCHEMY_URL` check in `hardhat.config.ts`
- Add consistent spacing after `if` keyword in `NFT721.sol`
- Clean up extra blank lines in `safeMint` function body
- Add 2 missing tests for null-address royalty guard path (39 tests passing)
- Fix `package-lock.json` root package name mismatch (`hardhat-project` → `nft-erc721`)

## Test plan

- [x] All 39 tests passing locally (`npx hardhat test`)
- [ ] CI passes