### PR TITLE
standardize anchor test scaffolding for solana programs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,4 +107,5 @@ jobs:
       - name: Anchor test
         env:
           ANCHOR_TEST_TIME_SCALE: "0.85"
+          NODE_OPTIONS: "--preserve-symlinks"
         run: anchor test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
           avm use 1.0.1
           echo "$HOME/.avm/bin" >> $GITHUB_PATH
 
+      - name: Install Surfpool
+        run: cargo install --git https://github.com/txtx/surfpool --locked
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,13 @@ jobs:
       - name: Install Solana CLI
         uses: metaplex-foundation/actions/install-solana@v1
         with:
-          version: 2.1.0
+          version: 2.3.0
 
       - name: Install Anchor
         run: |
           cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
-          avm install 0.32.1
-          avm use 0.32.1
+          avm install 1.0.1
+          avm use 1.0.1
           echo "$HOME/.avm/bin" >> $GITHUB_PATH
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,17 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      evm-dirs: ${{ steps.find.outputs.dirs }}
+      evm-dirs: ${{ steps.find-evm.outputs.dirs }}
+      solana-dirs: ${{ steps.find-solana.outputs.dirs }}
     steps:
       - uses: actions/checkout@v4
-      - id: find
+      - id: find-evm
         run: |
-          # Find all directories containing either hardhat.config.ts or foundry.toml
           dirs=$(find evm -maxdepth 2 \( -name "hardhat.config.ts" -o -name "hardhat.config.js" -o -name "foundry.toml" \) -exec dirname {} \; | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          echo "dirs=$dirs" >> $GITHUB_OUTPUT
+      - id: find-solana
+        run: |
+          dirs=$(find solana -maxdepth 2 -name Anchor.toml -exec dirname {} \; | sort -u | jq -R -s -c 'split("\n")[:-1]')
           echo "dirs=$dirs" >> $GITHUB_OUTPUT
 
   evm:
@@ -60,3 +64,44 @@ jobs:
       - name: Test (Foundry)
         if: hashFiles(format('{0}/foundry.toml', matrix.dir)) != ''
         run: forge test -vvv
+
+  solana:
+    needs: detect
+    if: needs.detect.outputs.solana-dirs != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dir: ${{ fromJson(needs.detect.outputs.solana-dirs) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ${{ matrix.dir }}/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Solana CLI
+        uses: metaplex-foundation/actions/install-solana@v1
+        with:
+          version: 2.1.0
+
+      - name: Install Anchor
+        run: |
+          cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
+          avm install 0.32.1
+          avm use 0.32.1
+          echo "$HOME/.avm/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Anchor test
+        env:
+          ANCHOR_TEST_TIME_SCALE: "0.85"
+        run: anchor test

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Reusable smart contract templates for EVM (Solidity + Foundry) and Solana (Ancho
 - Multisig wallet
 - Subscription/billing
 
-## Solana Programs (Planned)
+## Solana Programs
 
-- SPL token creation
-- Staking program
-- Vesting program
-- Subscription program
+- Staking program (`solana/staking`)
+- SPL token creation (planned)
+- Vesting program (planned)
+- Subscription program (planned)
+
+Anchor integration tests use shared helpers in `solana/test-utils`. See [docs/testing-solana.md](./docs/testing-solana.md) for layout, CI, and how to add tests for a new program.
 
 Every contract includes a .learn.md with explanations and security considerations.

--- a/docs/testing-solana.md
+++ b/docs/testing-solana.md
@@ -1,0 +1,140 @@
+# Solana / Anchor testing convention
+
+This repo uses a shared layout and helpers so every Anchor program tests the same way.
+
+## Directory layout
+
+```
+solana/
+├── test-utils/              # shared TypeScript helpers (provider, airdrop, PDA, clock)
+└── <program-name>/          # one Anchor workspace per template
+    ├── Anchor.toml
+    ├── programs/<name>/
+    ├── tests/
+    │   ├── <program-name>.ts    # main mocha suite (matches program name)
+    │   └── helpers/               # program-only helpers (PDAs, fixtures)
+    ├── package.json
+    └── tsconfig.json
+```
+
+- Test entry file: `tests/<program-name>.ts` (e.g. `tests/staking.ts`).
+- Reuse `solana/test-utils` for provider setup, funding, generic PDAs, and time helpers.
+- Put seeds and fixtures that are specific to one program under `tests/helpers/`.
+
+## Shared test utilities
+
+Package: `solana/test-utils` (`@w3-kit/solana-test-utils`).
+
+| Helper | Purpose |
+|--------|---------|
+| `setupProvider()` | `AnchorProvider.env()` + returns `connection` and `payer` |
+| `loadProgram(name)` | Typed `anchor.workspace` program handle |
+| `fundKeypairs(connection, keypairs, sol?)` | Parallel airdrops with confirmation |
+| `findPda(programId, seeds)` | `PublicKey.findProgramAddressSync` wrapper |
+| `getChainClock(connection)` | Current slot + unix timestamp for assertions |
+| `waitSeconds` / `waitScaledSeconds` | Real-time waits when the program uses `Clock` sysvar |
+
+Wire it in `package.json`:
+
+```json
+{
+  "dependencies": {
+    "@w3-kit/solana-test-utils": "file:../test-utils"
+  }
+}
+```
+
+## Typical test file skeleton
+
+```typescript
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { Keypair } from "@solana/web3.js";
+import { expect } from "chai";
+import {
+  setupProvider,
+  fundKeypairs,
+} from "@w3-kit/solana-test-utils";
+import { MyProgram } from "../target/types/my_program";
+
+describe("my-program", () => {
+  const { connection, payer } = setupProvider();
+  const program = anchor.workspace.MyProgram as Program<MyProgram>;
+
+  const user = Keypair.generate();
+
+  before(async () => {
+    await fundKeypairs(connection, [user]);
+  });
+
+  it("does something", async () => {
+    // ...
+  });
+});
+```
+
+## Program-specific PDAs
+
+Keep seed lists next to the program under `tests/helpers/`:
+
+```typescript
+import { PublicKey } from "@solana/web3.js";
+import { findPda } from "@w3-kit/solana-test-utils";
+
+export function poolPda(
+  programId: PublicKey,
+  stakingMint: PublicKey,
+  rewardMint: PublicKey
+) {
+  return findPda(programId, ["pool", stakingMint.toBuffer(), rewardMint.toBuffer()]);
+}
+```
+
+## Clock and slots
+
+Many programs use `Clock::get()` for `unix_timestamp` or slot-based logic.
+
+| Approach | When to use |
+|----------|-------------|
+| **Short periods + `waitScaledSeconds`** | Default for `anchor test` on localnet (see `staking` tests) |
+| **`getChainClock`** | Assert block time before/after an instruction |
+| **Bankrun / LiteSVM** | Deterministic warp without real sleeps (add when tests become flaky or slow) |
+
+On the validator started by `anchor test`, you cannot warp unix time through the standard RPC. Prefer short reward periods in tests (seconds, not days) and optional `ANCHOR_TEST_TIME_SCALE=0.5` in CI to trim waits.
+
+Example (real time wait):
+
+```typescript
+import { waitScaledSeconds } from "@w3-kit/solana-test-utils";
+
+await fundVaultAndConfigure(..., new BN(1_000_000), new BN(5));
+await waitScaledSeconds(6); // past a 5-second reward period
+```
+
+## Running tests locally
+
+From the program directory (e.g. `solana/staking`):
+
+```bash
+npm ci
+anchor test
+```
+
+`anchor test` builds the program, starts a local validator, deploys, and runs the mocha suite defined in `Anchor.toml`:
+
+```toml
+[scripts]
+test = "npx ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+```
+
+## Adding tests for a new program
+
+1. Copy layout from `solana/staking` (Anchor.toml, `programs/`, `tests/`, `package.json`).
+2. Add `"@w3-kit/solana-test-utils": "file:../test-utils"` to `package.json`.
+3. Create `tests/<program-name>.ts` using `setupProvider` and `fundKeypairs`.
+4. Add program PDAs under `tests/helpers/`.
+5. CI picks up any directory under `solana/` that contains `Anchor.toml` (see `.github/workflows/ci.yml`).
+
+## Reference implementation
+
+`solana/staking` is the canonical example: full suite in `tests/staking.ts`, PDAs in `tests/helpers/staking.ts`, shared utils for provider, airdrop, and time waits.

--- a/solana/staking/README.md
+++ b/solana/staking/README.md
@@ -91,8 +91,11 @@ After deployment, create the pool and start rewards:
 
 ## Testing
 
+Shared Anchor test helpers live in `solana/test-utils`. See [docs/testing-solana.md](../../docs/testing-solana.md) for layout and how to add tests for new programs.
+
 ```bash
-anchor test --validator legacy
+npm ci
+anchor test
 ```
 
 Tests cover:

--- a/solana/staking/package-lock.json
+++ b/solana/staking/package-lock.json
@@ -8,7 +8,8 @@
       "dependencies": {
         "@coral-xyz/anchor": "^0.32.1",
         "@solana/spl-token": "^0.4.0",
-        "@solana/web3.js": "^1.95.0"
+        "@solana/web3.js": "^1.95.0",
+        "@w3-kit/solana-test-utils": "file:../test-utils"
       },
       "devDependencies": {
         "@types/bn.js": "^5.1.0",
@@ -18,6 +19,19 @@
         "mocha": "^9.0.3",
         "ts-mocha": "^10.0.0",
         "typescript": "^5.7.3"
+      }
+    },
+    "../test-utils": {
+      "name": "@w3-kit/solana-test-utils",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@coral-xyz/anchor": "^0.32.1",
+        "@solana/web3.js": "^1.95.0",
+        "typescript": "^5.7.3"
+      },
+      "peerDependencies": {
+        "@coral-xyz/anchor": "^0.32.0",
+        "@solana/web3.js": "^1.95.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -604,6 +618,10 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@w3-kit/solana-test-utils": {
+      "resolved": "../test-utils",
+      "link": true
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",

--- a/solana/staking/package.json
+++ b/solana/staking/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",
     "@solana/web3.js": "^1.95.0",
-    "@solana/spl-token": "^0.4.0"
+    "@solana/spl-token": "^0.4.0",
+    "@w3-kit/solana-test-utils": "file:../test-utils"
   },
   "devDependencies": {
     "chai": "^4.3.4",

--- a/solana/staking/tests/helpers/staking.ts
+++ b/solana/staking/tests/helpers/staking.ts
@@ -1,0 +1,26 @@
+import { PublicKey } from "@solana/web3.js";
+import { findPda, type PdaResult } from "@w3-kit/solana-test-utils";
+
+export function findPoolPda(
+  programId: PublicKey,
+  stakingMint: PublicKey,
+  rewardMint: PublicKey
+): PdaResult {
+  return findPda(programId, [
+    "pool",
+    stakingMint.toBuffer(),
+    rewardMint.toBuffer(),
+  ]);
+}
+
+export function findUserStakePda(
+  programId: PublicKey,
+  pool: PublicKey,
+  user: PublicKey
+): PdaResult {
+  return findPda(programId, [
+    "user_stake",
+    pool.toBuffer(),
+    user.toBuffer(),
+  ]);
+}

--- a/solana/staking/tests/staking.ts
+++ b/solana/staking/tests/staking.ts
@@ -11,45 +11,22 @@ import {
   TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
+import { PublicKey, Keypair, SystemProgram } from "@solana/web3.js";
 import {
-  PublicKey,
-  Keypair,
-  SystemProgram,
-  LAMPORTS_PER_SOL,
-} from "@solana/web3.js";
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+  setupProvider,
+  fundKeypairs,
+  waitScaledSeconds,
+} from "@w3-kit/solana-test-utils";
+import { findPoolPda, findUserStakePda } from "./helpers/staking";
 
 describe("Staking", () => {
-  const provider = anchor.AnchorProvider.env();
-  anchor.setProvider(provider);
+  const { connection, payer } = setupProvider();
   const program = anchor.workspace.Staking as Program<Staking>;
-  const connection = provider.connection;
-  const payer = (provider.wallet as anchor.Wallet).payer;
 
   const alice = Keypair.generate();
   const bob = Keypair.generate();
 
   // ---- helpers ----
-
-  function getPoolPda(sMint: PublicKey, rMint: PublicKey): [PublicKey, number] {
-    return PublicKey.findProgramAddressSync(
-      [Buffer.from("pool"), sMint.toBuffer(), rMint.toBuffer()],
-      program.programId
-    );
-  }
-
-  function getUserStakePda(
-    pool: PublicKey,
-    user: PublicKey
-  ): [PublicKey, number] {
-    return PublicKey.findProgramAddressSync(
-      [Buffer.from("user_stake"), pool.toBuffer(), user.toBuffer()],
-      program.programId
-    );
-  }
 
   async function createTestMints(): Promise<{
     stakingMint: PublicKey;
@@ -76,15 +53,15 @@ describe("Staking", () => {
     stakingMint: PublicKey,
     rewardMint: PublicKey
   ): Promise<{ poolPda: PublicKey; stakingVault: PublicKey; rewardVault: PublicKey }> {
-    const [poolPda] = getPoolPda(stakingMint, rewardMint);
+    const [pool] = findPoolPda(program.programId, stakingMint, rewardMint);
     const stakingVault = getAssociatedTokenAddressSync(
       stakingMint,
-      poolPda,
+      pool,
       true
     );
     const rewardVault = getAssociatedTokenAddressSync(
       rewardMint,
-      poolPda,
+      pool,
       true
     );
 
@@ -94,7 +71,7 @@ describe("Staking", () => {
         authority: payer.publicKey,
         stakingMint,
         rewardMint,
-        pool: poolPda,
+        pool,
         stakingVault,
         rewardVault,
         systemProgram: SystemProgram.programId,
@@ -103,7 +80,7 @@ describe("Staking", () => {
       })
       .rpc();
 
-    return { poolPda, stakingVault, rewardVault };
+    return { poolPda: pool, stakingVault, rewardVault };
   }
 
   async function setupUser(
@@ -149,7 +126,11 @@ describe("Staking", () => {
     stakingVault: PublicKey,
     userStakingAta: PublicKey
   ) {
-    const [userStakePda] = getUserStakePda(poolPda, user.publicKey);
+    const [userStakePda] = findUserStakePda(
+      program.programId,
+      poolPda,
+      user.publicKey
+    );
     await program.methods
       .stake(amount)
       .accounts({
@@ -206,14 +187,7 @@ describe("Staking", () => {
   // ---- setup ----
 
   before(async () => {
-    const [aliceSig, bobSig] = await Promise.all([
-      connection.requestAirdrop(alice.publicKey, 10 * LAMPORTS_PER_SOL),
-      connection.requestAirdrop(bob.publicKey, 10 * LAMPORTS_PER_SOL),
-    ]);
-    await Promise.all([
-      connection.confirmTransaction(aliceSig),
-      connection.confirmTransaction(bobSig),
-    ]);
+    await fundKeypairs(connection, [alice, bob]);
   });
 
   // ------------------------------------------------------------------
@@ -265,7 +239,7 @@ describe("Staking", () => {
 
     it("rejects same staking and reward mint", async () => {
       const mint = await createMint(connection, payer, payer.publicKey, null, 6);
-      const [samePool] = getPoolPda(mint, mint);
+      const [samePool] = findPoolPda(program.programId, mint, mint);
       const vault = getAssociatedTokenAddressSync(mint, samePool, true);
 
       try {
@@ -326,7 +300,7 @@ describe("Staking", () => {
       const amount = new BN(100_000);
       await stakeTokens(alice, amount, poolPda, stakingVault, aliceAta);
 
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       const userStake = await fetchUserStake(userStakePda);
       expect(userStake.balance.toNumber()).to.equal(100_000);
     });
@@ -362,7 +336,7 @@ describe("Staking", () => {
       const pool = await fetchPool(poolPda);
       expect(pool.totalStaked.toNumber()).to.equal(300_000);
 
-      const [bobStakePda] = getUserStakePda(poolPda, bob.publicKey);
+      const [bobStakePda] = findUserStakePda(program.programId, poolPda, bob.publicKey);
       const bobStake = await fetchUserStake(bobStakePda);
       expect(bobStake.balance.toNumber()).to.equal(200_000);
     });
@@ -370,7 +344,7 @@ describe("Staking", () => {
     it("accumulates multiple stakes from the same user", async () => {
       await stakeTokens(alice, new BN(50_000), poolPda, stakingVault, aliceAta);
 
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       const userStake = await fetchUserStake(userStakePda);
       expect(userStake.balance.toNumber()).to.equal(150_000);
 
@@ -403,7 +377,7 @@ describe("Staking", () => {
     });
 
     it("withdraws tokens and updates balances", async () => {
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
 
       await program.methods
         .withdraw(new BN(200_000))
@@ -433,7 +407,7 @@ describe("Staking", () => {
     });
 
     it("reverts on zero amount", async () => {
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       try {
         await program.methods
           .withdraw(new BN(0))
@@ -454,7 +428,7 @@ describe("Staking", () => {
     });
 
     it("reverts when withdrawing more than staked", async () => {
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       try {
         await program.methods
           .withdraw(new BN(999_999_999))
@@ -475,7 +449,7 @@ describe("Staking", () => {
     });
 
     it("supports partial withdrawals leaving remaining balance", async () => {
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
 
       await program.methods
         .withdraw(new BN(100_000))
@@ -609,13 +583,13 @@ describe("Staking", () => {
       await fundVaultAndConfigure(rewardMint, rewardVault, poolPda, new BN(1_000_000), new BN(10));
 
       // Wait ~5 seconds (half the period)
-      await sleep(5000);
+      await waitScaledSeconds(5);
 
       // Trigger reward update by staking a tiny amount
       await mintTo(connection, payer, stakingMint, stakingAta, payer, 1);
       await stakeTokens(alice, new BN(1), poolPda, stakingVault, stakingAta);
 
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       const userStake = await fetchUserStake(userStakePda);
       const earned = userStake.rewardsEarned.toNumber();
 
@@ -636,13 +610,13 @@ describe("Staking", () => {
       await fundVaultAndConfigure(rewardMint, rewardVault, poolPda, new BN(1_000_000), new BN(5));
 
       // Wait for full period + buffer
-      await sleep(7000);
+      await waitScaledSeconds(7);
 
       // Trigger update
       await mintTo(connection, payer, stakingMint, stakingAta, payer, 1);
       await stakeTokens(alice, new BN(1), poolPda, stakingVault, stakingAta);
 
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       const userStake = await fetchUserStake(userStakePda);
       const earned = userStake.rewardsEarned.toNumber();
 
@@ -679,7 +653,7 @@ describe("Staking", () => {
       await fundVaultAndConfigure(rewardMint, rewardVault, poolPda, new BN(1_000_000), new BN(5));
 
       // Wait for full period
-      await sleep(7000);
+      await waitScaledSeconds(7);
 
       // Trigger updates for both
       await mintTo(connection, payer, stakingMint, aliceAta, payer, 1);
@@ -687,8 +661,8 @@ describe("Staking", () => {
       await mintTo(connection, payer, stakingMint, bobAta, payer, 1);
       await stakeTokens(bob, new BN(1), poolPda, stakingVault, bobAta);
 
-      const [aliceStakePda] = getUserStakePda(poolPda, alice.publicKey);
-      const [bobStakePda] = getUserStakePda(poolPda, bob.publicKey);
+      const [aliceStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
+      const [bobStakePda] = findUserStakePda(program.programId, poolPda, bob.publicKey);
 
       const aliceEarned = (await fetchUserStake(aliceStakePda)).rewardsEarned.toNumber();
       const bobEarned = (await fetchUserStake(bobStakePda)).rewardsEarned.toNumber();
@@ -717,17 +691,17 @@ describe("Staking", () => {
       await fundVaultAndConfigure(rewardMint, rewardVault, poolPda, new BN(1_000_000), new BN(3));
 
       // Wait well past the period end
-      await sleep(5000);
+      await waitScaledSeconds(5);
 
       // Trigger first update
       await mintTo(connection, payer, stakingMint, stakingAta, payer, 1);
       await stakeTokens(alice, new BN(1), poolPda, stakingVault, stakingAta);
 
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       const earned1 = (await fetchUserStake(userStakePda)).rewardsEarned.toNumber();
 
       // Wait more time
-      await sleep(3000);
+      await waitScaledSeconds(3);
 
       // Trigger second update
       await mintTo(connection, payer, stakingMint, stakingAta, payer, 1);
@@ -750,13 +724,13 @@ describe("Staking", () => {
       await fundVaultAndConfigure(rewardMint, rewardVault, poolPda, new BN(1_000_000), new BN(3));
 
       // Wait for period to pass
-      await sleep(5000);
+      await waitScaledSeconds(5);
 
       // Now stake — should not get retroactive rewards
       const { stakingAta } = await setupUser(alice, stakingMint, rewardMint, 10_000_000);
       await stakeTokens(alice, new BN(100_000), poolPda, stakingVault, stakingAta);
 
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       const userStake = await fetchUserStake(userStakePda);
 
       expect(userStake.rewardsEarned.toNumber()).to.equal(0);
@@ -799,13 +773,13 @@ describe("Staking", () => {
       );
 
       // Wait for period to finish
-      await sleep(5000);
+      await waitScaledSeconds(5);
     });
 
     it("transfers reward tokens to user", async () => {
       const rewardBefore = await getTokenBalance(aliceRewardAta);
 
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       await program.methods
         .claimReward()
         .accounts({
@@ -828,7 +802,7 @@ describe("Staking", () => {
     });
 
     it("resets rewards earned to zero after claiming", async () => {
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       const userStake = await fetchUserStake(userStakePda);
       expect(userStake.rewardsEarned.toNumber()).to.equal(0);
     });
@@ -836,7 +810,7 @@ describe("Staking", () => {
     it("is a no-op when no rewards earned", async () => {
       const rewardBefore = await getTokenBalance(aliceRewardAta);
 
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       await program.methods
         .claimReward()
         .accounts({
@@ -891,14 +865,14 @@ describe("Staking", () => {
       );
 
       // Wait for period to finish
-      await sleep(5000);
+      await waitScaledSeconds(5);
     });
 
     it("withdraws all staked tokens and claims rewards in one transaction", async () => {
       const stakingBefore = await getTokenBalance(aliceStakingAta);
       const rewardBefore = await getTokenBalance(aliceRewardAta);
 
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       await program.methods
         .exit()
         .accounts({
@@ -936,7 +910,7 @@ describe("Staking", () => {
     });
 
     it("reverts when nothing is staked", async () => {
-      const [userStakePda] = getUserStakePda(poolPda, alice.publicKey);
+      const [userStakePda] = findUserStakePda(program.programId, poolPda, alice.publicKey);
       try {
         await program.methods
           .exit()
@@ -980,7 +954,7 @@ describe("Staking", () => {
         .rpc();
 
       // Wait for period to end
-      await sleep(4000);
+      await waitScaledSeconds(4);
 
       // Should succeed
       await program.methods

--- a/solana/staking/tsconfig.json
+++ b/solana/staking/tsconfig.json
@@ -5,6 +5,10 @@
     "lib": ["es2015"],
     "module": "commonjs",
     "target": "es6",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@w3-kit/solana-test-utils": ["../test-utils/src/index.ts"]
+    }
   }
 }

--- a/solana/test-utils/package.json
+++ b/solana/test-utils/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@w3-kit/solana-test-utils",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared helpers for Anchor integration tests in w3-kit/contracts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@coral-xyz/anchor": "^0.32.0",
+    "@solana/web3.js": "^1.95.0"
+  },
+  "devDependencies": {
+    "@coral-xyz/anchor": "^0.32.1",
+    "@solana/web3.js": "^1.95.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/solana/test-utils/src/airdrop.ts
+++ b/solana/test-utils/src/airdrop.ts
@@ -1,0 +1,22 @@
+import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
+
+const DEFAULT_SOL = 10;
+
+/**
+ * Funds one or more keypairs via requestAirdrop on localnet / devnet.
+ */
+export async function fundKeypairs(
+  connection: Connection,
+  keypairs: Keypair[],
+  solAmount = DEFAULT_SOL
+): Promise<void> {
+  const lamports = solAmount * LAMPORTS_PER_SOL;
+
+  const signatures = await Promise.all(
+    keypairs.map((kp) => connection.requestAirdrop(kp.publicKey, lamports))
+  );
+
+  await Promise.all(
+    signatures.map((sig) => connection.confirmTransaction(sig, "confirmed"))
+  );
+}

--- a/solana/test-utils/src/clock.ts
+++ b/solana/test-utils/src/clock.ts
@@ -1,0 +1,53 @@
+import { Connection } from "@solana/web3.js";
+
+export interface ChainClock {
+  slot: number;
+  unixTimestamp: number;
+}
+
+/**
+ * Reads the current slot and block time from the cluster.
+ * Useful for assertions around time-based program logic.
+ */
+export async function getChainClock(
+  connection: Connection
+): Promise<ChainClock> {
+  const slot = await connection.getSlot("confirmed");
+  const unixTimestamp = (await connection.getBlockTime(slot)) ?? 0;
+  return { slot, unixTimestamp };
+}
+
+export function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Waits for real time to pass on the local validator.
+ *
+ * Programs that read Clock::get() cannot warp unix time on the default
+ * anchor test validator. Keep reward periods short in tests, or use a
+ * Bankrun / LiteSVM setup for deterministic clock control (see docs/testing-solana.md).
+ */
+export async function waitSeconds(seconds: number): Promise<void> {
+  await sleepMs(seconds * 1000);
+}
+
+/**
+ * Scale wait duration in CI via ANCHOR_TEST_TIME_SCALE (e.g. 0.5 halves waits).
+ * Defaults to 1.
+ */
+export function scaledWaitMs(baseMs: number): number {
+  const raw = process.env.ANCHOR_TEST_TIME_SCALE;
+  if (!raw) {
+    return baseMs;
+  }
+  const scale = Number.parseFloat(raw);
+  if (!Number.isFinite(scale) || scale <= 0) {
+    return baseMs;
+  }
+  return Math.max(100, Math.floor(baseMs * scale));
+}
+
+export async function waitScaledSeconds(seconds: number): Promise<void> {
+  await sleepMs(scaledWaitMs(seconds * 1000));
+}

--- a/solana/test-utils/src/index.ts
+++ b/solana/test-utils/src/index.ts
@@ -1,0 +1,11 @@
+export { setupProvider, loadProgram, type TestContext } from "./provider";
+export { fundKeypairs } from "./airdrop";
+export { findPda, type PdaResult } from "./pda";
+export {
+  getChainClock,
+  sleepMs,
+  waitSeconds,
+  waitScaledSeconds,
+  scaledWaitMs,
+  type ChainClock,
+} from "./clock";

--- a/solana/test-utils/src/pda.ts
+++ b/solana/test-utils/src/pda.ts
@@ -1,0 +1,16 @@
+import { PublicKey } from "@solana/web3.js";
+
+export type PdaResult = [PublicKey, number];
+
+/**
+ * Derives a program address from seed segments (strings or buffers).
+ */
+export function findPda(
+  programId: PublicKey,
+  seeds: Array<string | Buffer | Uint8Array>
+): PdaResult {
+  const buffers = seeds.map((seed) =>
+    typeof seed === "string" ? Buffer.from(seed) : Buffer.from(seed)
+  );
+  return PublicKey.findProgramAddressSync(buffers, programId);
+}

--- a/solana/test-utils/src/provider.ts
+++ b/solana/test-utils/src/provider.ts
@@ -1,0 +1,33 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { Keypair } from "@solana/web3.js";
+
+export interface TestContext {
+  provider: anchor.AnchorProvider;
+  connection: anchor.web3.Connection;
+  payer: Keypair;
+}
+
+/**
+ * Uses AnchorProvider.env() (cluster + wallet from Anchor.toml).
+ * Call anchor.setProvider(provider) once in the test entry file.
+ */
+export function setupProvider(): TestContext {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const wallet = provider.wallet as anchor.Wallet;
+  const payer = wallet.payer;
+
+  return {
+    provider,
+    connection: provider.connection,
+    payer,
+  };
+}
+
+export function loadProgram<T extends anchor.Idl>(
+  name: string
+): Program<T> {
+  return anchor.workspace[name] as Program<T>;
+}

--- a/solana/test-utils/tsconfig.json
+++ b/solana/test-utils/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "lib": ["es2015"],
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
hey team, picked up #27 since solana staking already had a big test file but everything was duplicated inline and ci only ran evm stuff.

what this does:
- `docs/testing-solana.md` documents the layout (`tests/<program>.ts`, `tests/helpers/`, shared utils)
- `solana/test-utils` has provider setup, airdrop funding, generic pda helper, and clock wait helpers (with optional `ANCHOR_TEST_TIME_SCALE` for ci)
- staking tests refactored to use those helpers as the reference program
- ci matrix finds any `solana/*/Anchor.toml` and runs `anchor test` there

staking reward tests still wait on real localnet time (clock sysvar), but periods stay short and waits can be scaled down in ci. doc mentions bankrun if someone needs deterministic warp later.

closes #27